### PR TITLE
fix, Jumping from *SymflowerTest.java file to the implementation

### DIFF
--- a/rc/symflower.kak
+++ b/rc/symflower.kak
@@ -22,7 +22,7 @@ define-command symflower-disable -docstring "Disable unit test generation on sav
 }
 
 define-command symflower-alternative-file -docstring 'Jump to the alternate file (implementation ↔ Symflower test)' %{ evaluate-commands %sh{
-	case "$kak_buffile" in
+	case "$kak_buffile" in # REMARK Cases are ordered to match specific extensions first and general language files last.
 	(*_symflower_test.go)
 		altfile=${kak_buffile%_symflower_test.go}.go
 		test ! -f "$altfile" && echo "fail 'implementation file not found'" && exit
@@ -35,13 +35,13 @@ define-command symflower-alternative-file -docstring 'Jump to the alternate file
 		altfile=${kak_buffile%.go}_symflower_test.go
 		test ! -f "$altfile" && echo "fail 'Symflower test file not found'" && exit
 		;;
-	(*.java)
-		altfile=${kak_buffile%.java}SymflowerTest.java
-		test ! -f "$altfile" && echo "fail 'Symflower test file not found'" && exit
-		;;
 	(*SymflowerTest.java)
 		altfile=${kak_buffile%SymflowerTest.java}.java
 		test ! -f "$altfile" && echo "fail 'implementation file not found'" && exit
+		;;
+	(*.java)
+		altfile=${kak_buffile%.java}SymflowerTest.java
+		test ! -f "$altfile" && echo "fail 'Symflower test file not found'" && exit
 		;;
 	(*)
 		echo "fail 'alternative file not found'" && exit


### PR DESCRIPTION
The switch statement in symflower-alternative-file has two cases
*.java and *SymflowerTest.java. Since the first check subsumes
the second, that one is dead code, so we fail to jump back to the
implementation. Let's switch the order, which also matches the semantic
order of the Go cases.

This reverts commit c495c23 (refactor, Sort, 2022-01-08).
