### PR TITLE
Log symflower commands to the *symflower* buffer

### DIFF
--- a/rc/symflower.kak
+++ b/rc/symflower.kak
@@ -5,7 +5,12 @@ Any arguments are forwarded to the 'symflower' command.
 } %{ evaluate-commands %sh{
 	output=$(mktemp -d "${TMPDIR:-/tmp}"/symflower-kakoune.XXXXXXXX)/fifo
 	mkfifo ${output}
-	( symflower "$@" > ${output} 2>&1 & ) >/dev/null 2>&1 </dev/null
+	(
+		(
+			printf %s\\n "\$ symflower $*"
+			symflower "$@"
+		) > ${output} 2>&1 &
+	) >/dev/null 2>&1 </dev/null
 
 	printf %s\\n "evaluate-commands -draft %{
 		edit! -fifo ${output} -scroll *symflower*


### PR DESCRIPTION
The output of Symflower CLI are displayed in the *symflower* buffer.
Sometimes it can be helpful to show the shell command that produced
the results results, especially when a user passed filter arguments.
Add the shell command before its output.
